### PR TITLE
Update RenderListMarker.cpp

### DIFF
--- a/Source/WebCore/rendering/RenderListMarker.cpp
+++ b/Source/WebCore/rendering/RenderListMarker.cpp
@@ -1373,9 +1373,12 @@ void RenderListMarker::layout()
     ASSERT(needsLayout());
  
     if (isImage()) {
-        updateMarginsAndContent();
-        setWidth(m_image->imageSize(this, style().effectiveZoom()).width());
-        setHeight(m_image->imageSize(this, style().effectiveZoom()).height());
+        int bulletWidth = style()->fontMetrics().ascent() / 2;
+        IntSize defaultBulletSize(bulletWidth, bulletWidth);
+        IntSize imageSize = calculateImageIntrinsicDimensions(m_image.get(), defaultBulletSize, DoNotScaleByEffectiveZoom);
+        setWidth(m_image->setContainerSizeForLayoutObject(this, imageSize, style()->effectiveZoom()).width());
+        setHeight(m_image->setContainerSizeForLayoutObject(this, imageSize, style()->effectiveZoom()).height());
+        return;
     } else {
         setLogicalWidth(minPreferredLogicalWidth());
         setLogicalHeight(style().fontMetrics().height());


### PR DESCRIPTION
This fixes a problem where svg bullet icons cannot not resize according to screen size and will show small regardless of screen size. please visit the bug at https://code.google.com/p/chromium/issues/detail?id=350734
