### PR TITLE
Cookie test must also check for HttpOnly

### DIFF
--- a/LayoutTests/http/tests/media/resources/setCookie.cgi
+++ b/LayoutTests/http/tests/media/resources/setCookie.cgi
@@ -9,5 +9,5 @@ print "Cache-Control: no-store\n";
 print 'Cache-Control: no-cache="set-cookie"' . "\n";
 
 # We only map the SET_COOKIE request header to "Set-Cookie"
-print "Set-Cookie: TEST_HTTP_ONLY=${name}; HttpOnly\n\n";
+print "Set-Cookie: TEST_HTTP_ONLY=${name}; HttpOnly\n";
 print "Set-Cookie: TEST=${name}; HttpOnly\n\n";

--- a/LayoutTests/http/tests/media/resources/setCookie.cgi
+++ b/LayoutTests/http/tests/media/resources/setCookie.cgi
@@ -9,4 +9,5 @@ print "Cache-Control: no-store\n";
 print 'Cache-Control: no-cache="set-cookie"' . "\n";
 
 # We only map the SET_COOKIE request header to "Set-Cookie"
-print "Set-Cookie: TEST=${name}\n\n";
+print "Set-Cookie: TEST_HTTP_ONLY=${name}; HttpOnly\n\n";
+print "Set-Cookie: TEST=${name}; HttpOnly\n\n";

--- a/LayoutTests/http/tests/media/resources/setCookie.cgi
+++ b/LayoutTests/http/tests/media/resources/setCookie.cgi
@@ -10,4 +10,4 @@ print 'Cache-Control: no-cache="set-cookie"' . "\n";
 
 # We only map the SET_COOKIE request header to "Set-Cookie"
 print "Set-Cookie: TEST_HTTP_ONLY=${name}; HttpOnly\n";
-print "Set-Cookie: TEST=${name}; HttpOnly\n\n";
+print "Set-Cookie: TEST=${name}\n\n";

--- a/LayoutTests/http/tests/media/resources/video-cookie-check-httponly.php
+++ b/LayoutTests/http/tests/media/resources/video-cookie-check-httponly.php
@@ -1,0 +1,23 @@
+<?php
+    if($_COOKIE["TEST_HTTP_ONLY"])
+    {
+        $extension = pathinfo($_COOKIE["TEST_HTTP_ONLY"], PATHINFO_EXTENSION);
+        if ($extension == 'mp4') {
+               header("Content-Type: video/mp4");
+               $fileName = "test.mp4";
+        } else if ($extension == 'ogv') {
+               header("Content-Type: video/ogg");
+               $fileName = "test.ogv";
+        } else if ($extension == 'ts') {
+               header("Content-Type: video/mpegts");
+               $fileName = "hls/test.ts";
+        } else
+               die;
+        header("Cache-Control: no-store");
+        header("Connection: close");
+        $fn = fopen($fileName, "r");
+        fpassthru($fn);
+        fclose($fn);
+        exit;
+    }
+?>

--- a/LayoutTests/http/tests/media/video-cookie-httponly-expected.txt
+++ b/LayoutTests/http/tests/media/video-cookie-httponly-expected.txt
@@ -1,2 +1,2 @@
 EVENT(canplay)
-Tests that the media player will send the relevant cookies when requesting the media file.
+Tests that the media player will send the relevant httponly cookies when requesting the media file.

--- a/LayoutTests/http/tests/media/video-cookie-httponly-expected.txt
+++ b/LayoutTests/http/tests/media/video-cookie-httponly-expected.txt
@@ -1,0 +1,2 @@
+EVENT(canplay)
+Tests that the media player will send the relevant cookies when requesting the media file.

--- a/LayoutTests/http/tests/media/video-cookie-httponly.html
+++ b/LayoutTests/http/tests/media/video-cookie-httponly.html
@@ -17,7 +17,7 @@
         document.body.appendChild(frame);
         frame.addEventListener('load', function () {
                 video = document.getElementById('video');
-                video.src="http://127.0.0.1:8000/media/resources/video-cookie-check-cookie-httponly.php";
+                video.src="http://127.0.0.1:8000/media/resources/video-cookie-check-httponly.php";
                 video.play();
         });
         frame.width = 0;

--- a/LayoutTests/http/tests/media/video-cookie-httponly.html
+++ b/LayoutTests/http/tests/media/video-cookie-httponly.html
@@ -1,0 +1,34 @@
+<html>
+<head>
+</head>
+<body onload="loadCookie()">
+<video id="video"></video>
+<script src=../../media-resources/video-test.js></script>
+<script src=../../media-resources/media-file.js></script>
+<script>
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.setAlwaysAcceptCookies(true);
+        testRunner.waitUntilDone();
+    }
+    function loadCookie () {
+        var movie = findMediaFile("video", "resources/test");
+        var frame = document.createElement("iframe");
+        document.body.appendChild(frame);
+        frame.addEventListener('load', function () {
+                video = document.getElementById('video');
+                video.src="http://127.0.0.1:8000/media/resources/video-cookie-check-cookie-httponly.php";
+                video.play();
+        });
+        frame.width = 0;
+        frame.height = 0;
+        frame.src = "http://127.0.0.1:8000/media/resources/setCookie.cgi?name=" + movie;
+    }
+    waitForEvent("canplay", function () {
+        if (window.testRunner)
+            window.testRunner.notifyDone();
+    } );
+</script>
+Tests that the media player will send the relevant cookies when requesting the media file.<br/>
+</body>
+</html>

--- a/LayoutTests/http/tests/media/video-cookie-httponly.html
+++ b/LayoutTests/http/tests/media/video-cookie-httponly.html
@@ -29,6 +29,6 @@
             window.testRunner.notifyDone();
     } );
 </script>
-Tests that the media player will send the relevant cookies when requesting the media file.<br/>
+Tests that the media player will send the relevant httponly cookies when requesting the media file.<br/>
 </body>
 </html>


### PR DESCRIPTION
iOS had a nasty bug in iOS 7.0.4, where cookies had been missing for requests send from VideoPlayers. (Original openradar: http://openradar.appspot.com/radar?id=5238098090786816; test script: https://www.bizify.me/test-if-your-ios-device-is-broken/)

This bug is back in iOS 10 GM, though neither Safari nightly nor Safari Technology preview are affected.

This time however only the Javascript allowed cookies are send to the server, not the HttpOnly cookies.

This test coverage is missing in WebKit as well, because it also does not specifically test for HttpOnly cookies, which usually are excluded from client side Javascript.
