### PR TITLE
This causes mjpg-streamer webcam based streams to flicker

### DIFF
--- a/Source/WebKit2/Shared/WebPreferencesDefinitions.h
+++ b/Source/WebKit2/Shared/WebPreferencesDefinitions.h
@@ -267,7 +267,7 @@
     macro(ApplePayCapabilityDisclosureAllowed, applePayCapabilityDisclosureAllowed, Bool, bool, true, "", "") \
     macro(VisualViewportEnabled, visualViewportEnabled, Bool, bool, true, "", "") \
     macro(NeedsStorageAccessFromFileURLsQuirk, needsStorageAccessFromFileURLsQuirk, Bool, bool, true, "", "") \
-    macro(LargeImageAsyncDecodingEnabled, largeImageAsyncDecodingEnabled, Bool, bool, true, "", "") \
+    macro(LargeImageAsyncDecodingEnabled, largeImageAsyncDecodingEnabled, Bool, bool, false, "", "") \
     macro(AnimatedImageAsyncDecodingEnabled, animatedImageAsyncDecodingEnabled, Bool, bool, true, "", "") \
     macro(CustomElementsEnabled, customElementsEnabled, Bool, bool, true, "", "") \
     macro(EncryptedMediaAPIEnabled, encryptedMediaAPIEnabled, Bool, bool, false, "", "") \


### PR DESCRIPTION
This causes mjpg-streamer webcam based streams to flicker. This may be experimental but cause this issue. Please provide some way to overcome by using JS or other Client Side Scripting Languages.

See a screencast here https://www.youtube.com/watch?v=5ABeC_SaWoE&feature=youtu.be