### PR TITLE
Update Speedometer version number to 2

### DIFF
--- a/PerformanceTests/Speedometer/index.html
+++ b/PerformanceTests/Speedometer/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-    <title>Speedometer 1.0</title>
+    <title>Speedometer 2.0</title>
     <link rel="stylesheet" href="resources/main.css">
     <script src="resources/main.js" defer></script>
     <script src="resources/benchmark-runner.js" defer></script>

--- a/Websites/browserbench.org/Speedometer2.0/index.html
+++ b/Websites/browserbench.org/Speedometer2.0/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-    <title>Speedometer 1.0</title>
+    <title>Speedometer 2.0</title>
     <link rel="stylesheet" href="resources/main.css">
     <script src="resources/main.js" defer></script>
     <script src="resources/benchmark-runner.js" defer></script>


### PR DESCRIPTION
This is confusing many people on our side: the website and performance tests still indicate Speedometer version 1, although it is the version 2.

@Constellation, can you have a look, please? Thanks!