### PR TITLE
fix for mac brew to run as non admin user

### DIFF
--- a/Tools/gtk/install-dependencies
+++ b/Tools/gtk/install-dependencies
@@ -38,7 +38,9 @@ function checkInstaller {
     fi
 
     if [ `uname` = "Darwin" ]; then
-       installDependenciesWithBrew
+       username=$(stat -f '%Su' /usr/local/Cellar)
+       FUNC=$(declare -f installDependenciesWithBrew)
+       sudo -u $username bash -c "$FUNC;installDependenciesWithBrew"
        exit 0
     fi
 


### PR DESCRIPTION
dropping back to owner of /usr/local/cellar, the correct user with permissions to run brew scripts.